### PR TITLE
chore: update docblock to valid docblock

### DIFF
--- a/src/Concerns/InteractsWithElements.php
+++ b/src/Concerns/InteractsWithElements.php
@@ -99,7 +99,7 @@ trait InteractsWithElements
      * Send the given keys to the element matching the given selector.
      *
      * @param  string  $selector
-     * @param  dynamic  $keys
+     * @param  mixed  $keys
      * @return $this
      */
     public function keys($selector, ...$keys)


### PR DESCRIPTION
`dynamic` isn't a valid annotation. This breaks static analyzers. Found this: https://github.com/laravel/framework/issues/25061  suggesting that updates from `dynamic` --> `mixed` would be welcome.

I ran into this while working on https://github.com/psalm/psalm-plugin-laravel
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
